### PR TITLE
Add local testing with MiniWDL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ ifeq ($(shell which miniwdl),)
 $(error Please install requirements using "pip install -r requirements.txt")
 endif
 
+# MiniWDL uses shellcheck for improved WDL linting. This check can be removed if folks dislike it.
 ifeq ($(shell which shellcheck),)
 $(error Please install shellcheck using "apt-get install shellcheck" or "brew install shellcheck")
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+ifeq ($(shell which miniwdl),)
+$(error Please install requirements using "pip install -r requirements.txt")
+endif
+
+ifeq ($(shell which shellcheck),)
+$(error Please install shellcheck using "apt-get install shellcheck" or "brew install shellcheck")
+endif
+
+test: plugin
+	miniwdl run --verbose drs_downloader_to_getm.wdl --input test/input/inputs.json
+
+plugin:
+	pip install --upgrade --no-cache-dir scripts/inject_gs_credentials
+
+clean:
+	git clean -dfX
+
+.PHONY: test plugin

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # getm-tests
 Tests for getm
+
+## local testing
+To test the workflow on your local machine using [MiniWDL](https://github.com/chanzuckerberg/miniwdl.git):
+
+Install requirements
+```
+pip install -r requirements.txt
+sudo apt-get install shellcheck
+gcloud auth application-default login
+```
+
+Authenticate
+```
+gcloud auth application-default login
+```
+
+Run local tests
+```
+make test
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests
+miniwdl
+six

--- a/scripts/inject_gs_credentials/inject_credentials.py
+++ b/scripts/inject_gs_credentials/inject_credentials.py
@@ -10,17 +10,18 @@ import WDL.Value
 
 def main(cfg, logger, run_id, run_dir, task, **recv):
     # Include GCP credentials in task input
-    p = os.path.join(os.path.expanduser("~"), ".config", "gcloud")
-    if not os.path.exists(p) or not os.path.isfile(os.path.join(p, "application_default_credentials.json")):
-        msg = ("GCP credentials are expected in `~/.config/gcloud`"
-               "Please authenticate with GCP using `gcloud auth application-default login`")
+    gcloud_config_dir = os.path.join(os.path.expanduser("~"), ".config", "gcloud")
+    if (not os.path.exists(gcloud_config_dir)
+            or not os.path.isfile(os.path.join(gcloud_config_dir, "application_default_credentials.json"))):
+        msg = ("GCP credentials are expected in '~/.config/gcloud'. "
+               "Please authenticate with GCP using 'gcloud auth application-default login'")
         raise RuntimeError(msg)
-    recv['inputs'] = recv['inputs'].bind("gcp_credentials", WDL.Value.Directory(p))
+    recv['inputs'] = recv['inputs'].bind("gcp_credentials", WDL.Value.Directory(gcloud_config_dir))
     recv = yield recv
 
     # inject credentials
     for host_path, container_path in recv['container'].input_path_map.items():
-        if p in host_path:
+        if host_path.startswith(gcloud_config_dir):
             recv['command'] = _inject_sh.format(container_path=container_path) + "\n\n" + recv["command"]
             recv = yield recv
             break

--- a/scripts/inject_gs_credentials/inject_credentials.py
+++ b/scripts/inject_gs_credentials/inject_credentials.py
@@ -1,0 +1,33 @@
+"""
+miniwdl plugin to inject GCP credentials into workflow tasks.
+"""
+import os
+import tempfile
+from contextlib import contextmanager
+
+import WDL.Value
+
+
+def main(cfg, logger, run_id, run_dir, task, **recv):
+    # Include GCP credentials in task input
+    p = os.path.join(os.path.expanduser("~"), ".config", "gcloud")
+    if not os.path.exists(p) or not os.path.isfile(os.path.join(p, "application_default_credentials.json")):
+        msg = ("GCP credentials are expected in `~/.config/gcloud`"
+               "Please authenticate with GCP using `gcloud auth application-default login`")
+        raise RuntimeError(msg)
+    recv['inputs'] = recv['inputs'].bind("gcp_credentials", WDL.Value.Directory(p))
+    recv = yield recv
+
+    # inject credentials
+    for host_path, container_path in recv['container'].input_path_map.items():
+        if p in host_path:
+            recv['command'] = _inject_sh.format(container_path=container_path) + "\n\n" + recv["command"]
+            recv = yield recv
+            break
+    else:
+        raise RuntimeError("Credentials not found input path map!")
+
+    # do nothing with outputs
+    yield recv
+
+_inject_sh = """mkdir -p ~/.config && cp -r {container_path} ~/.config"""

--- a/scripts/inject_gs_credentials/setup.py
+++ b/scripts/inject_gs_credentials/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='inject_gcloud_credentials',
+    version='0.0.1',
+    description='miniwdl plugin to inject gcloud credentials. This is for local testing.',
+    author='Brian Hannafious',
+    py_modules=["inject_credentials"],
+    python_requires='>=3.6',
+    setup_requires=[],
+    install_requires=[""],
+    reentry_register=True,
+    entry_points={
+        'miniwdl.plugin.task': ['inject_credentials = inject_credentials:main'],
+    }
+)


### PR DESCRIPTION
Local workflow testing is pretty useful for workflow development!

[MiniWDL](https://github.com/chanzuckerberg/miniwdl.git) is a
relatively lightweight WDL executor, making it useful for
local testing.

This also adds a MiniWDL plugin to inject gcloud credentials into
the local workflow execution environment.