### PR TITLE
Allow download to fail and still produce results.

### DIFF
--- a/drs_downloader_to_getm.wdl
+++ b/drs_downloader_to_getm.wdl
@@ -231,6 +231,7 @@ task download {
         if [ ! -f "~{downloader}.txt" ]; then
             echo "~{downloader} -1 seconds" > "~{downloader}.txt"
         fi
+    >>>
 
     output {
         File timing_file = "~{downloader}.txt"

--- a/drs_downloader_to_getm.wdl
+++ b/drs_downloader_to_getm.wdl
@@ -231,6 +231,7 @@ task download {
                 echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
             fi
         )
+        # if the output file was not created due to some error above, create a record of the error with a stub file and -1 seconds:
         if [ ! -f "~{downloader}.txt" ]; then
             echo "~{downloader} -1 seconds" > "~{downloader}.txt"
         fi

--- a/drs_downloader_to_getm.wdl
+++ b/drs_downloader_to_getm.wdl
@@ -183,7 +183,7 @@ task download {
                 start_time=`date +%s`
                 signed_urls=($(cat ~{manifest} | jq -r '.[] .url'))
                 for signed_url in ${signed_urls[@]}; do
-                    curl ${signed_url} -P ${TMP_DL_DIR}/
+                    curl ${signed_url} --output ${TMP_DL_DIR}/${RANDOM}
                 done
                 end_time=`date +%s`
                 total_time="$(($end_time-$start_time))"

--- a/drs_downloader_to_getm.wdl
+++ b/drs_downloader_to_getm.wdl
@@ -235,6 +235,7 @@ task download {
         if [ ! -f "~{downloader}.txt" ]; then
             echo "~{downloader} -1 seconds" > "~{downloader}.txt"
         fi
+    >>>
 
     output {
         File timing_file = "~{downloader}.txt"

--- a/drs_downloader_to_getm.wdl
+++ b/drs_downloader_to_getm.wdl
@@ -164,7 +164,7 @@ task download {
                 start_time=`date +%s`
                 signed_urls=($(cat ~{manifest} | jq -r '.[] .url'))
                 for signed_url in ${signed_urls[@]}; do
-                    wget ${signed_url} --output-document=${TMP_DL_DIR}/$(basename $signed_url)
+                    wget ${signed_url} -P ${TMP_DL_DIR}/
                 done
                 end_time=`date +%s`
                 total_time="$(($end_time-$start_time))"
@@ -183,7 +183,7 @@ task download {
                 start_time=`date +%s`
                 signed_urls=($(cat ~{manifest} | jq -r '.[] .url'))
                 for signed_url in ${signed_urls[@]}; do
-                    curl ${signed_url} -o ${TMP_DL_DIR}/$(basename $signed_url)
+                    curl ${signed_url} -P ${TMP_DL_DIR}/
                 done
                 end_time=`date +%s`
                 total_time="$(($end_time-$start_time))"

--- a/drs_downloader_to_getm.wdl
+++ b/drs_downloader_to_getm.wdl
@@ -291,7 +291,7 @@ task consolidate_outputs {
     >>>
 
     output {
-        File final_timing_totals = "final_timing_totals.txt"
+        File final_timing_totals = "final_timing_totals.json"
     }
 
     runtime {

--- a/drs_downloader_to_getm.wdl
+++ b/drs_downloader_to_getm.wdl
@@ -110,122 +110,122 @@ task download {
             # everything in parenthesis will proceed until an error is hit, it will then exit the subshell,
             # and will continue executing the next line in the parent shell
             # this is a sort of rudimentary error handling, so that "~{downloader}.txt" is always produced
-        set -eux o pipefail
+            set -eux o pipefail
 
-        # Where all non-getm downloads go (wget, gsutil, and curl)
-        TMP_DL_DIR=/cromwell_root/speedtest3crdws3s
-        mkdir -p ${TMP_DL_DIR}
+            # Where all non-getm downloads go (wget, gsutil, and curl)
+            TMP_DL_DIR=/cromwell_root/speedtest3crdws3s
+            mkdir -p ${TMP_DL_DIR}
 
-        # Identify the runtime environment; Check Linux version
-        cat /etc/issue
-        uname -a
-        apt-get update
-        apt-get install -yq --no-install-recommends apt-utils git jq
+            # Identify the runtime environment; Check Linux version
+            cat /etc/issue
+            uname -a
+            apt-get update
+            apt-get install -yq --no-install-recommends apt-utils git jq
 
-        # Check available shared memory and disk usage before downloading
-        # TODO Configure shared memory appropriately, if needed.
-        df -h
-
-        if [ "~{downloader}" = "getm" ]; then
-            apt-get install -yq --no-install-recommends python3.8-dev
-            apt-get -yq --no-install-recommends install python3-pip
-            # Check that we're really using python3.8
-            python --version
-
-            # Install getm
-            python -m pip install --upgrade pip
-            python -m pip install git+https://github.com/xbrianh/getm
-            python -m pip show getm
-
-            # Download the files in the manifest
-            start_time=`date +%s`
-            time getm -c -v --manifest ~{manifest}
-            getm_exit_status=$?
-            echo "Getm exit status: "$getm_exit_status
-            end_time=`date +%s`
-            total_time="$(($end_time-$start_time))"
-            # Check final disk usage after downloading
+            # Check available shared memory and disk usage before downloading
+            # TODO Configure shared memory appropriately, if needed.
             df -h
 
-            # verify that the downloaded filepaths exist
-            downloaded_files=($(cat ~{manifest} | jq -r '.[] .filepath'))
-            for downloaded_file in ${downloaded_files[@]}; do
-                echo ${downloaded_file}
-                ls -lha ${downloaded_file}
-            done
-            echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
-        fi
+            if [ "~{downloader}" = "getm" ]; then
+                apt-get install -yq --no-install-recommends python3.8-dev
+                apt-get -yq --no-install-recommends install python3-pip
+                # Check that we're really using python3.8
+                python --version
 
-        # WGET DOWNLOAD of the signed URLs in the manifest
-        if [ "~{downloader}" = "wget" ]; then
-            apt-get install -yq --no-install-recommends wget
-            start_time=`date +%s`
-            signed_urls=($(cat ~{manifest} | jq -r '.[] .url'))
-            for signed_url in ${signed_urls[@]}; do
-                wget ${signed_url} -P ${TMP_DL_DIR}/
-            done
-            end_time=`date +%s`
-            total_time="$(($end_time-$start_time))"
+                # Install getm
+                python -m pip install --upgrade pip
+                python -m pip install git+https://github.com/xbrianh/getm
+                python -m pip show getm
 
-            # time just the md5sums
-            md5sum ${TMP_DL_DIR}/*
-            end_time=`date +%s`
-            total_time_incl_md5="$(($end_time-$start_time))"
-            echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
-            echo "~{downloader}_md5sum ${total_time_incl_md5} seconds" >> "~{downloader}.txt"
-        fi
+                # Download the files in the manifest
+                start_time=`date +%s`
+                time getm -c -v --manifest ~{manifest}
+                getm_exit_status=$?
+                echo "Getm exit status: "$getm_exit_status
+                end_time=`date +%s`
+                total_time="$(($end_time-$start_time))"
+                # Check final disk usage after downloading
+                df -h
 
-        # CURL DOWNLOAD of the signed URLs in the manifest
-        if [ "~{downloader}" = "curl" ]; then
-            start_time=`date +%s`
-            signed_urls=($(cat ~{manifest} | jq -r '.[] .url'))
-            for signed_url in ${signed_urls[@]}; do
-                curl ${signed_url} --output ${TMP_DL_DIR}/${RANDOM}
-            done
-            end_time=`date +%s`
-            total_time="$(($end_time-$start_time))"
+                # verify that the downloaded filepaths exist
+                downloaded_files=($(cat ~{manifest} | jq -r '.[] .filepath'))
+                for downloaded_file in ${downloaded_files[@]}; do
+                    echo ${downloaded_file}
+                    ls -lha ${downloaded_file}
+                done
+                echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
+            fi
 
-            # time just the md5sums
-            md5sum ${TMP_DL_DIR}/*
-            end_time=`date +%s`
-            total_time_incl_md5="$(($end_time-$start_time))"
-            echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
-            echo "~{downloader}_md5sum ${total_time_incl_md5} seconds" >> "~{downloader}.txt"
-        fi
+            # WGET DOWNLOAD of the signed URLs in the manifest
+            if [ "~{downloader}" = "wget" ]; then
+                apt-get install -yq --no-install-recommends wget
+                start_time=`date +%s`
+                signed_urls=($(cat ~{manifest} | jq -r '.[] .url'))
+                for signed_url in ${signed_urls[@]}; do
+                    wget ${signed_url} -P ${TMP_DL_DIR}/
+                done
+                end_time=`date +%s`
+                total_time="$(($end_time-$start_time))"
 
-        # GSUTIL DOWNLOAD of the gs:// URIs in the manifest
-        if [ "~{downloader}" = "gsutil" ]; then
-            # Google project to bill for the gsutil downloads
-            GOOGLE_REQUESTER_PAYS_PROJECT=anvil-stage-demo
-            apt-get install -y apt-transport-https ca-certificates gnupg
-            echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-            apt-get update -y && apt-get install -y google-cloud-sdk
+                # time just the md5sums
+                md5sum ${TMP_DL_DIR}/*
+                end_time=`date +%s`
+                total_time_incl_md5="$(($end_time-$start_time))"
+                echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
+                echo "~{downloader}_md5sum ${total_time_incl_md5} seconds" >> "~{downloader}.txt"
+            fi
 
-            start_time=`date +%s`
-            google_uris=($(cat ~{manifest} | jq -r '.[] .gs_uri'))
-            for google_uri in ${google_uris[@]}; do
-                gsutil -u ${GOOGLE_REQUESTER_PAYS_PROJECT} cp ${google_uri} ${TMP_DL_DIR}/
-            done
-            end_time=`date +%s`
-            total_time="$(($end_time-$start_time))"
-            echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
-        fi
+            # CURL DOWNLOAD of the signed URLs in the manifest
+            if [ "~{downloader}" = "curl" ]; then
+                start_time=`date +%s`
+                signed_urls=($(cat ~{manifest} | jq -r '.[] .url'))
+                for signed_url in ${signed_urls[@]}; do
+                    curl ${signed_url} --output ${TMP_DL_DIR}/${RANDOM}
+                done
+                end_time=`date +%s`
+                total_time="$(($end_time-$start_time))"
 
-        # CROMWELL LOCALIZER DOWNLOAD of the drs:// URIs in the manifest
-        if [ "~{downloader}" = "cromwell_localizer" ]; then
-            # Google project to bill for the localizer downloads (which seems to call gsutil)
-            GOOGLE_REQUESTER_PAYS_PROJECT=anvil-stage-demo
-            export MARTHA_URL=https://us-central1-broad-dsde-prod.cloudfunctions.net/martha_v3
-            drs_uris=($(cat ~{manifest} | jq -r '.[] .drs_uri'))
-            start_time=`date +%s`
-            for drs_uri in ${drs_uris[@]}; do
-                java -jar /app/cromwell-drs-localizer.jar ${drs_uri} ${TMP_DL_DIR} ${GOOGLE_REQUESTER_PAYS_PROJECT}
-            done
-            end_time=`date +%s`
-            total_time="$(($end_time-$start_time))"
-            echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
-        fi
+                # time just the md5sums
+                md5sum ${TMP_DL_DIR}/*
+                end_time=`date +%s`
+                total_time_incl_md5="$(($end_time-$start_time))"
+                echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
+                echo "~{downloader}_md5sum ${total_time_incl_md5} seconds" >> "~{downloader}.txt"
+            fi
+
+            # GSUTIL DOWNLOAD of the gs:// URIs in the manifest
+            if [ "~{downloader}" = "gsutil" ]; then
+                # Google project to bill for the gsutil downloads
+                GOOGLE_REQUESTER_PAYS_PROJECT=anvil-stage-demo
+                apt-get install -y apt-transport-https ca-certificates gnupg
+                echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+                curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+                apt-get update -y && apt-get install -y google-cloud-sdk
+
+                start_time=`date +%s`
+                google_uris=($(cat ~{manifest} | jq -r '.[] .gs_uri'))
+                for google_uri in ${google_uris[@]}; do
+                    gsutil -u ${GOOGLE_REQUESTER_PAYS_PROJECT} cp ${google_uri} ${TMP_DL_DIR}/
+                done
+                end_time=`date +%s`
+                total_time="$(($end_time-$start_time))"
+                echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
+            fi
+
+            # CROMWELL LOCALIZER DOWNLOAD of the drs:// URIs in the manifest
+            if [ "~{downloader}" = "cromwell_localizer" ]; then
+                # Google project to bill for the localizer downloads (which seems to call gsutil)
+                GOOGLE_REQUESTER_PAYS_PROJECT=anvil-stage-demo
+                export MARTHA_URL=https://us-central1-broad-dsde-prod.cloudfunctions.net/martha_v3
+                drs_uris=($(cat ~{manifest} | jq -r '.[] .drs_uri'))
+                start_time=`date +%s`
+                for drs_uri in ${drs_uris[@]}; do
+                    java -jar /app/cromwell-drs-localizer.jar ${drs_uri} ${TMP_DL_DIR} ${GOOGLE_REQUESTER_PAYS_PROJECT}
+                done
+                end_time=`date +%s`
+                total_time="$(($end_time-$start_time))"
+                echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
+            fi
         )
         # if the output file was not created due to some error above, create a record of the error with a stub file and -1 seconds:
         if [ ! -f "~{downloader}.txt" ]; then

--- a/drs_downloader_to_getm.wdl
+++ b/drs_downloader_to_getm.wdl
@@ -106,125 +106,133 @@ task download {
         Int? disk
     }
     command <<<
-        set -eux o pipefail
+        (   # <- open a subshell
+            # everything in parenthesis will proceed until an error is hit, it will then exit the subshell,
+            # and will continue executing the next line in the parent shell
+            # this is a sort of rudimentary error handling, so that "~{downloader}.txt" is always produced
+            set -eux o pipefail
 
-        CURRENT_DIR=$(pwd)
+            CURRENT_DIR=$(pwd)
 
-        # Where all non-getm downloads go (wget, gsutil, and curl)
-        TMP_DL_DIR=/cromwell_root/speedtest3crdws3s
-        mkdir -p ${TMP_DL_DIR}
+            # Where all non-getm downloads go (wget, gsutil, and curl)
+            TMP_DL_DIR=/cromwell_root/speedtest3crdws3s
+            mkdir -p ${TMP_DL_DIR}
 
-        # Identify the runtime environment; Check Linux version
-        cat /etc/issue
-        uname -a
-        apt-get update
-        apt-get install -yq --no-install-recommends apt-utils git jq
+            # Identify the runtime environment; Check Linux version
+            cat /etc/issue
+            uname -a
+            apt-get update
+            apt-get install -yq --no-install-recommends apt-utils git jq
 
-        # Check available shared memory and disk usage before downloading
-        # TODO Configure shared memory appropriately, if needed.
-        df -h
-
-        if [ "~{downloader}" = "getm" ]; then
-            apt-get install -yq --no-install-recommends python3.8-dev
-            apt-get -yq --no-install-recommends install python3-pip
-            # Check that we're really using python3.8
-            python --version
-
-            # Install getm
-            python -m pip install --upgrade pip
-            python -m pip install git+https://github.com/xbrianh/getm
-            python -m pip show getm
-
-            # Download the files in the manifest
-            start_time=`date +%s`
-            time getm -c -v --manifest ~{manifest}
-            getm_exit_status=$?
-            echo "Getm exit status: "$getm_exit_status
-            end_time=`date +%s`
-            total_time="$(($end_time-$start_time))"
-            # Check final disk usage after downloading
+            # Check available shared memory and disk usage before downloading
+            # TODO Configure shared memory appropriately, if needed.
             df -h
 
-            # verify that the downloaded filepaths exist
-            downloaded_files=($(cat ~{manifest} | jq -r '.[] .filepath'))
-            for downloaded_file in ${downloaded_files[@]}; do
-                echo ${downloaded_file}
-                ls -lha ${downloaded_file}
-            done
-            echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
-        fi
+            if [ "~{downloader}" = "getm" ]; then
+                apt-get install -yq --no-install-recommends python3.8-dev
+                apt-get -yq --no-install-recommends install python3-pip
+                # Check that we're really using python3.8
+                python --version
 
-        # WGET DOWNLOAD of the signed URLs in the manifest
-        if [ "~{downloader}" = "wget" ]; then
-            apt-get install -yq --no-install-recommends wget
-            start_time=`date +%s`
-            signed_urls=($(cat ~{manifest} | jq -r '.[] .url'))
-            for signed_url in ${signed_urls[@]}; do
-                wget ${signed_url} --output-document=${TMP_DL_DIR}/$(basename $signed_url)
-            done
-            end_time=`date +%s`
-            total_time="$(($end_time-$start_time))"
+                # Install getm
+                python -m pip install --upgrade pip
+                python -m pip install git+https://github.com/xbrianh/getm
+                python -m pip show getm
 
-            # time just the md5sums
-            md5sum ${TMP_DL_DIR}/*
-            end_time=`date +%s`
-            total_time_incl_md5="$(($end_time-$start_time))"
-            echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
-            echo "~{downloader}_md5sum ${total_time_incl_md5} seconds" >> "~{downloader}.txt"
-        fi
+                # Download the files in the manifest
+                start_time=`date +%s`
+                time getm -c -v --manifest ~{manifest}
+                getm_exit_status=$?
+                echo "Getm exit status: "$getm_exit_status
+                end_time=`date +%s`
+                total_time="$(($end_time-$start_time))"
+                # Check final disk usage after downloading
+                df -h
 
-        # CURL DOWNLOAD of the signed URLs in the manifest
-        if [ "~{downloader}" = "curl" ]; then
-            cd ${TMP_DL_DIR}
-            start_time=`date +%s`
-            signed_urls=($(cat ~{manifest} | jq -r '.[] .url'))
-            for signed_url in ${signed_urls[@]}; do
-                curl ${signed_url} -o ${TMP_DL_DIR}/$(basename $signed_url)
-            done
-            end_time=`date +%s`
-            total_time="$(($end_time-$start_time))"
+                # verify that the downloaded filepaths exist
+                downloaded_files=($(cat ~{manifest} | jq -r '.[] .filepath'))
+                for downloaded_file in ${downloaded_files[@]}; do
+                    echo ${downloaded_file}
+                    ls -lha ${downloaded_file}
+                done
+                echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
+            fi
 
-            # time just the md5sums
-            md5sum ${TMP_DL_DIR}/*
-            end_time=`date +%s`
-            total_time_incl_md5="$(($end_time-$start_time))"
-            echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
-            echo "~{downloader}_md5sum ${total_time_incl_md5} seconds" >> "~{downloader}.txt"
-            cd ${CURRENT_DIR}
-        fi
+            # WGET DOWNLOAD of the signed URLs in the manifest
+            if [ "~{downloader}" = "wget" ]; then
+                apt-get install -yq --no-install-recommends wget
+                start_time=`date +%s`
+                signed_urls=($(cat ~{manifest} | jq -r '.[] .url'))
+                for signed_url in ${signed_urls[@]}; do
+                    wget ${signed_url} --output-document=${TMP_DL_DIR}/$(basename $signed_url)
+                done
+                end_time=`date +%s`
+                total_time="$(($end_time-$start_time))"
 
-        # GSUTIL DOWNLOAD of the gs:// URIs in the manifest
-        if [ "~{downloader}" = "gsutil" ]; then
-            # Google project to bill for the gsutil downloads
-            GOOGLE_REQUESTER_PAYS_PROJECT=anvil-stage-demo
-            apt-get install -y apt-transport-https ca-certificates gnupg
-            echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-            curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-            apt-get update -y && apt-get install -y google-cloud-sdk
+                # time just the md5sums
+                md5sum ${TMP_DL_DIR}/*
+                end_time=`date +%s`
+                total_time_incl_md5="$(($end_time-$start_time))"
+                echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
+                echo "~{downloader}_md5sum ${total_time_incl_md5} seconds" >> "~{downloader}.txt"
+            fi
 
-            start_time=`date +%s`
-            google_uris=($(cat ~{manifest} | jq -r '.[] .gs_uri'))
-            for google_uri in ${google_uris[@]}; do
-                gsutil -u ${GOOGLE_REQUESTER_PAYS_PROJECT} cp ${google_uri} ${TMP_DL_DIR}/
-            done
-            end_time=`date +%s`
-            total_time="$(($end_time-$start_time))"
-            echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
-        fi
+            # CURL DOWNLOAD of the signed URLs in the manifest
+            if [ "~{downloader}" = "curl" ]; then
+                cd ${TMP_DL_DIR}
+                start_time=`date +%s`
+                signed_urls=($(cat ~{manifest} | jq -r '.[] .url'))
+                for signed_url in ${signed_urls[@]}; do
+                    curl ${signed_url} -o ${TMP_DL_DIR}/$(basename $signed_url)
+                done
+                end_time=`date +%s`
+                total_time="$(($end_time-$start_time))"
 
-        # CROMWELL LOCALIZER DOWNLOAD of the drs:// URIs in the manifest
-        if [ "~{downloader}" = "cromwell_localizer" ]; then
-            # Google project to bill for the localizer downloads (which seems to call gsutil)
-            GOOGLE_REQUESTER_PAYS_PROJECT=anvil-stage-demo
-            export MARTHA_URL=https://us-central1-broad-dsde-prod.cloudfunctions.net/martha_v3
-            drs_uris=($(cat ~{manifest} | jq -r '.[] .drs_uri'))
-            start_time=`date +%s`
-            for drs_uri in ${drs_uris[@]}; do
-                java -jar /app/cromwell-drs-localizer.jar ${drs_uri} ${TMP_DL_DIR} ${GOOGLE_REQUESTER_PAYS_PROJECT}
-            done
-            end_time=`date +%s`
-            total_time="$(($end_time-$start_time))"
-            echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
+                # time just the md5sums
+                md5sum ${TMP_DL_DIR}/*
+                end_time=`date +%s`
+                total_time_incl_md5="$(($end_time-$start_time))"
+                echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
+                echo "~{downloader}_md5sum ${total_time_incl_md5} seconds" >> "~{downloader}.txt"
+                cd ${CURRENT_DIR}
+            fi
+
+            # GSUTIL DOWNLOAD of the gs:// URIs in the manifest
+            if [ "~{downloader}" = "gsutil" ]; then
+                # Google project to bill for the gsutil downloads
+                GOOGLE_REQUESTER_PAYS_PROJECT=anvil-stage-demo
+                apt-get install -y apt-transport-https ca-certificates gnupg
+                echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+                curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+                apt-get update -y && apt-get install -y google-cloud-sdk
+
+                start_time=`date +%s`
+                google_uris=($(cat ~{manifest} | jq -r '.[] .gs_uri'))
+                for google_uri in ${google_uris[@]}; do
+                    gsutil -u ${GOOGLE_REQUESTER_PAYS_PROJECT} cp ${google_uri} ${TMP_DL_DIR}/
+                done
+                end_time=`date +%s`
+                total_time="$(($end_time-$start_time))"
+                echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
+            fi
+
+            # CROMWELL LOCALIZER DOWNLOAD of the drs:// URIs in the manifest
+            if [ "~{downloader}" = "cromwell_localizer" ]; then
+                # Google project to bill for the localizer downloads (which seems to call gsutil)
+                GOOGLE_REQUESTER_PAYS_PROJECT=anvil-stage-demo
+                export MARTHA_URL=https://us-central1-broad-dsde-prod.cloudfunctions.net/martha_v3
+                drs_uris=($(cat ~{manifest} | jq -r '.[] .drs_uri'))
+                start_time=`date +%s`
+                for drs_uri in ${drs_uris[@]}; do
+                    java -jar /app/cromwell-drs-localizer.jar ${drs_uri} ${TMP_DL_DIR} ${GOOGLE_REQUESTER_PAYS_PROJECT}
+                done
+                end_time=`date +%s`
+                total_time="$(($end_time-$start_time))"
+                echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
+            fi
+        )
+        if [ ! -f "~{downloader}.txt" ]; then
+            echo "~{downloader} -1 seconds" > "~{downloader}.txt"
         fi
     >>>
 

--- a/drs_downloader_to_getm.wdl
+++ b/drs_downloader_to_getm.wdl
@@ -112,8 +112,6 @@ task download {
             # this is a sort of rudimentary error handling, so that "~{downloader}.txt" is always produced
             set -eux o pipefail
 
-            CURRENT_DIR=$(pwd)
-
             # Where all non-getm downloads go (wget, gsutil, and curl)
             TMP_DL_DIR=/cromwell_root/speedtest3crdws3s
             mkdir -p ${TMP_DL_DIR}
@@ -179,7 +177,6 @@ task download {
 
             # CURL DOWNLOAD of the signed URLs in the manifest
             if [ "~{downloader}" = "curl" ]; then
-                cd ${TMP_DL_DIR}
                 start_time=`date +%s`
                 signed_urls=($(cat ~{manifest} | jq -r '.[] .url'))
                 for signed_url in ${signed_urls[@]}; do
@@ -194,7 +191,6 @@ task download {
                 total_time_incl_md5="$(($end_time-$start_time))"
                 echo "~{downloader} ${total_time} seconds" > "~{downloader}.txt"
                 echo "~{downloader}_md5sum ${total_time_incl_md5} seconds" >> "~{downloader}.txt"
-                cd ${CURRENT_DIR}
             fi
 
             # GSUTIL DOWNLOAD of the gs:// URIs in the manifest

--- a/scripts/consolidate_files.py
+++ b/scripts/consolidate_files.py
@@ -1,12 +1,35 @@
-import sys, os
+import os
+import sys
+import json
+from datetime import datetime
+
+from terra_notebook_utils import table
 
 
 usage = "Usage: consolidate_files.py file_1 file_2 ..."
 assert len(sys.argv) >= 2, usage
 file_list = sys.argv[1:]
-with open('final_timing_totals.txt', 'w') as w:
-    for input_file in file_list:
-        if not os.path.exists(input_file):
-            raise RuntimeError(f'{input_file} does not exist.  {usage}')
-        with open(input_file, 'r') as r:
-            w.write(r.read() + '\n')
+timing_data = dict(date=datetime.utcnow().strftime("%Y-%m-%dT%H%M%S.%fZ"))
+for input_file in file_list:
+    if not os.path.exists(input_file):
+        raise RuntimeError(f'{input_file} does not exist.  {usage}')
+    with open(input_file, 'r') as fh:
+        try:
+            downloader_name, duration_seconds, _ = fh.readline().split()
+            timing_data[downloader_name] = duration_seconds
+            if downloader_name in ('wget', 'curl'):
+                if duration_seconds != '-1':
+                    time_w_md5sum = fh.readline().split()[1]
+                else:
+                    time_w_md5sum = '-1'
+                timing_data[f'{downloader_name}_md5sum'] = time_w_md5sum
+        except:
+            print(f'File contents ({input_file}): {fh.read()}')
+            raise
+
+
+
+table.put_row("results", timing_data, workspace="DRS Localization Testing", workspace_namespace="anvil-stage-demo")
+
+with open('final_timing_totals.json', 'wb') as fh:
+    fh.write(json.dumps(timing_data).encode("utf-8"))

--- a/scripts/consolidate_files.py
+++ b/scripts/consolidate_files.py
@@ -9,7 +9,8 @@ from terra_notebook_utils import table
 usage = "Usage: consolidate_files.py file_1 file_2 ..."
 assert len(sys.argv) >= 2, usage
 file_list = sys.argv[1:]
-timing_data = dict(date=datetime.utcnow().strftime("%Y-%m-%dT%H%M%S.%fZ"))
+# "0_data" displays this as the first column, since data tables in the browser show columns alphabetically
+timing_data = {'0_date': datetime.utcnow().strftime("%Y-%m-%dT%H%M%S.%fZ")}
 for input_file in file_list:
     if not os.path.exists(input_file):
         raise RuntimeError(f'{input_file} does not exist.  {usage}')
@@ -26,7 +27,6 @@ for input_file in file_list:
         except:
             print(f'File contents ({input_file}): {fh.read()}')
             raise
-
 
 
 table.put_row("results", timing_data, workspace="DRS Localization Testing", workspace_namespace="anvil-stage-demo")


### PR DESCRIPTION
stderr should still be visible in the event of a failure.  The workflow will "succeed" though, so you'll need to check the data table in order to figure out that a portion failed.

The diff displays a lot because of indenting, but the real diff is adding parenthesis around the original command to invoke a subshell which will execute each command, until it hits an error, the jump up to the parent shell and run after the subshell, something like:

```
(  # open subshell
    some set of commands
    more commands
)
# if the output file was not created due to some error above, create a record of the error with a stub file and -1 seconds:
if [ ! -f "~{downloader}.txt" ]; then
    echo "~{downloader} -1 seconds" > "~{downloader}.txt"
fi
```